### PR TITLE
Update source file headers to uniformly say GPLv3+ instead of GPLv2+

### DIFF
--- a/inst/+tblish/+examples/SpDb.m
+++ b/inst/+tblish/+examples/SpDb.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+examples/coplot.m
+++ b/inst/+tblish/+examples/coplot.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+examples/peel_off_name_value_options.m
+++ b/inst/+tblish/+examples/peel_off_name_value_options.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+examples/plot_pairs.m
+++ b/inst/+tblish/+examples/plot_pairs.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+examples/private/peelOffNameValueOptions.m
+++ b/inst/+tblish/+examples/private/peelOffNameValueOptions.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@AirPassengers/AirPassengers.m
+++ b/inst/+tblish/+internal/+datasets/@AirPassengers/AirPassengers.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@BJsales/BJsales.m
+++ b/inst/+tblish/+internal/+datasets/@BJsales/BJsales.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@BOD/BOD.m
+++ b/inst/+tblish/+internal/+datasets/@BOD/BOD.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@ChickWeight/ChickWeight.m
+++ b/inst/+tblish/+internal/+datasets/@ChickWeight/ChickWeight.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@DNase/DNase.m
+++ b/inst/+tblish/+internal/+datasets/@DNase/DNase.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@EuStockMarkets/EuStockMarkets.m
+++ b/inst/+tblish/+internal/+datasets/@EuStockMarkets/EuStockMarkets.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@Formaldehyde/Formaldehyde.m
+++ b/inst/+tblish/+internal/+datasets/@Formaldehyde/Formaldehyde.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@HairEyeColor/HairEyeColor.m
+++ b/inst/+tblish/+internal/+datasets/@HairEyeColor/HairEyeColor.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@Harman23cor/Harman23cor.m
+++ b/inst/+tblish/+internal/+datasets/@Harman23cor/Harman23cor.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@Harman74cor/Harman74cor.m
+++ b/inst/+tblish/+internal/+datasets/@Harman74cor/Harman74cor.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@Indometh/Indometh.m
+++ b/inst/+tblish/+internal/+datasets/@Indometh/Indometh.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@InsectSprays/InsectSprays.m
+++ b/inst/+tblish/+internal/+datasets/@InsectSprays/InsectSprays.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@JohnsonJohnson/JohnsonJohnson.m
+++ b/inst/+tblish/+internal/+datasets/@JohnsonJohnson/JohnsonJohnson.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@LakeHuron/LakeHuron.m
+++ b/inst/+tblish/+internal/+datasets/@LakeHuron/LakeHuron.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@LifeCycleSavings/LifeCycleSavings.m
+++ b/inst/+tblish/+internal/+datasets/@LifeCycleSavings/LifeCycleSavings.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@Loblolly/Loblolly.m
+++ b/inst/+tblish/+internal/+datasets/@Loblolly/Loblolly.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@Nile/Nile.m
+++ b/inst/+tblish/+internal/+datasets/@Nile/Nile.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@Orange/Orange.m
+++ b/inst/+tblish/+internal/+datasets/@Orange/Orange.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@OrchardSprays/OrchardSprays.m
+++ b/inst/+tblish/+internal/+datasets/@OrchardSprays/OrchardSprays.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@PlantGrowth/PlantGrowth.m
+++ b/inst/+tblish/+internal/+datasets/@PlantGrowth/PlantGrowth.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@Puromycin/Puromycin.m
+++ b/inst/+tblish/+internal/+datasets/@Puromycin/Puromycin.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@Theoph/Theoph.m
+++ b/inst/+tblish/+internal/+datasets/@Theoph/Theoph.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful, ...

--- a/inst/+tblish/+internal/+datasets/@Titanic/Titanic.m
+++ b/inst/+tblish/+internal/+datasets/@Titanic/Titanic.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@ToothGrowth/ToothGrowth.m
+++ b/inst/+tblish/+internal/+datasets/@ToothGrowth/ToothGrowth.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@UCBAdmissions/UCBAdmissions.m
+++ b/inst/+tblish/+internal/+datasets/@UCBAdmissions/UCBAdmissions.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@UKDriverDeaths/UKDriverDeaths.m
+++ b/inst/+tblish/+internal/+datasets/@UKDriverDeaths/UKDriverDeaths.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@UKLungDeaths/UKLungDeaths.m
+++ b/inst/+tblish/+internal/+datasets/@UKLungDeaths/UKLungDeaths.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@UKgas/UKgas.m
+++ b/inst/+tblish/+internal/+datasets/@UKgas/UKgas.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@USAccDeaths/USAccDeaths.m
+++ b/inst/+tblish/+internal/+datasets/@USAccDeaths/USAccDeaths.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@USArrests/USArrests.m
+++ b/inst/+tblish/+internal/+datasets/@USArrests/USArrests.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@USJudgeRatings/USJudgeRatings.m
+++ b/inst/+tblish/+internal/+datasets/@USJudgeRatings/USJudgeRatings.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@USPersonalExpenditure/USPersonalExpenditure.m
+++ b/inst/+tblish/+internal/+datasets/@USPersonalExpenditure/USPersonalExpenditure.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@VADeaths/VADeaths.m
+++ b/inst/+tblish/+internal/+datasets/@VADeaths/VADeaths.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@WWWusage/WWWusage.m
+++ b/inst/+tblish/+internal/+datasets/@WWWusage/WWWusage.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@WorldPhones/WorldPhones.m
+++ b/inst/+tblish/+internal/+datasets/@WorldPhones/WorldPhones.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@airmiles/airmiles.m
+++ b/inst/+tblish/+internal/+datasets/@airmiles/airmiles.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@airquality/airquality.m
+++ b/inst/+tblish/+internal/+datasets/@airquality/airquality.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@anscombe/anscombe.m
+++ b/inst/+tblish/+internal/+datasets/@anscombe/anscombe.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@attenu/attenu.m
+++ b/inst/+tblish/+internal/+datasets/@attenu/attenu.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@attitude/attitude.m
+++ b/inst/+tblish/+internal/+datasets/@attitude/attitude.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@austres/austres.m
+++ b/inst/+tblish/+internal/+datasets/@austres/austres.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@beavers/beavers.m
+++ b/inst/+tblish/+internal/+datasets/@beavers/beavers.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@cars/cars.m
+++ b/inst/+tblish/+internal/+datasets/@cars/cars.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@chickwts/chickwts.m
+++ b/inst/+tblish/+internal/+datasets/@chickwts/chickwts.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@co2/co2.m
+++ b/inst/+tblish/+internal/+datasets/@co2/co2.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@crimtab/crimtab.m
+++ b/inst/+tblish/+internal/+datasets/@crimtab/crimtab.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@cupcake/cupcake.m
+++ b/inst/+tblish/+internal/+datasets/@cupcake/cupcake.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@discoveries/discoveries.m
+++ b/inst/+tblish/+internal/+datasets/@discoveries/discoveries.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@esoph/esoph.m
+++ b/inst/+tblish/+internal/+datasets/@esoph/esoph.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@euro/euro.m
+++ b/inst/+tblish/+internal/+datasets/@euro/euro.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@eurodist/eurodist.m
+++ b/inst/+tblish/+internal/+datasets/@eurodist/eurodist.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@faithful/faithful.m
+++ b/inst/+tblish/+internal/+datasets/@faithful/faithful.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@freeny/freeny.m
+++ b/inst/+tblish/+internal/+datasets/@freeny/freeny.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@infert/infert.m
+++ b/inst/+tblish/+internal/+datasets/@infert/infert.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@iris/iris.m
+++ b/inst/+tblish/+internal/+datasets/@iris/iris.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@islands/islands.m
+++ b/inst/+tblish/+internal/+datasets/@islands/islands.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@lh/lh.m
+++ b/inst/+tblish/+internal/+datasets/@lh/lh.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@longley/longley.m
+++ b/inst/+tblish/+internal/+datasets/@longley/longley.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@lynx/lynx.m
+++ b/inst/+tblish/+internal/+datasets/@lynx/lynx.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@morley/morley.m
+++ b/inst/+tblish/+internal/+datasets/@morley/morley.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@mtcars/mtcars.m
+++ b/inst/+tblish/+internal/+datasets/@mtcars/mtcars.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@nhtemp/nhtemp.m
+++ b/inst/+tblish/+internal/+datasets/@nhtemp/nhtemp.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@nottem/nottem.m
+++ b/inst/+tblish/+internal/+datasets/@nottem/nottem.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@npk/npk.m
+++ b/inst/+tblish/+internal/+datasets/@npk/npk.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@occupationalStatus/occupationalStatus.m
+++ b/inst/+tblish/+internal/+datasets/@occupationalStatus/occupationalStatus.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@precip/precip.m
+++ b/inst/+tblish/+internal/+datasets/@precip/precip.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@presidents/presidents.m
+++ b/inst/+tblish/+internal/+datasets/@presidents/presidents.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@pressure/pressure.m
+++ b/inst/+tblish/+internal/+datasets/@pressure/pressure.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@quakes/quakes.m
+++ b/inst/+tblish/+internal/+datasets/@quakes/quakes.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@randu/randu.m
+++ b/inst/+tblish/+internal/+datasets/@randu/randu.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful, ...

--- a/inst/+tblish/+internal/+datasets/@rivers/rivers.m
+++ b/inst/+tblish/+internal/+datasets/@rivers/rivers.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@rock/rock.m
+++ b/inst/+tblish/+internal/+datasets/@rock/rock.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@sleep/sleep.m
+++ b/inst/+tblish/+internal/+datasets/@sleep/sleep.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@stackloss/stackloss.m
+++ b/inst/+tblish/+internal/+datasets/@stackloss/stackloss.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@state/state.m
+++ b/inst/+tblish/+internal/+datasets/@state/state.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful, ...

--- a/inst/+tblish/+internal/+datasets/@sunspot_month/sunspot_month.m
+++ b/inst/+tblish/+internal/+datasets/@sunspot_month/sunspot_month.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@sunspot_year/sunspot_year.m
+++ b/inst/+tblish/+internal/+datasets/@sunspot_year/sunspot_year.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful, ...

--- a/inst/+tblish/+internal/+datasets/@sunspots/sunspots.m
+++ b/inst/+tblish/+internal/+datasets/@sunspots/sunspots.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful, ...

--- a/inst/+tblish/+internal/+datasets/@swiss/swiss.m
+++ b/inst/+tblish/+internal/+datasets/@swiss/swiss.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@treering/treering.m
+++ b/inst/+tblish/+internal/+datasets/@treering/treering.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@trees/trees.m
+++ b/inst/+tblish/+internal/+datasets/@trees/trees.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@uspop/uspop.m
+++ b/inst/+tblish/+internal/+datasets/@uspop/uspop.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@volcano/volcano.m
+++ b/inst/+tblish/+internal/+datasets/@volcano/volcano.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@warpbreaks/warpbreaks.m
+++ b/inst/+tblish/+internal/+datasets/@warpbreaks/warpbreaks.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@women/women.m
+++ b/inst/+tblish/+internal/+datasets/@women/women.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+datasets/@zCO2/zCO2.m
+++ b/inst/+tblish/+internal/+datasets/@zCO2/zCO2.m
@@ -3,7 +3,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+table/blankTable.m
+++ b/inst/+tblish/+internal/+table/blankTable.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+table/defaultVarNames.m
+++ b/inst/+tblish/+internal/+table/defaultVarNames.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+table/fillValForType.m
+++ b/inst/+tblish/+internal/+table/fillValForType.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+table/fillValForTypeCtorStyle.m
+++ b/inst/+tblish/+internal/+table/fillValForTypeCtorStyle.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+table/fillValForTypeGeneric.m
+++ b/inst/+tblish/+internal/+table/fillValForTypeGeneric.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+table/fillValForVal.m
+++ b/inst/+tblish/+internal/+table/fillValForVal.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+table/gen_colvecfun.m
+++ b/inst/+tblish/+internal/+table/gen_colvecfun.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+table/matchrows.m
+++ b/inst/+tblish/+internal/+table/matchrows.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+table/mx_summary.m
+++ b/inst/+tblish/+internal/+table/mx_summary.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+table/resolveVarRef.m
+++ b/inst/+tblish/+internal/+table/resolveVarRef.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/+table/vartype_filter.m
+++ b/inst/+tblish/+internal/+table/vartype_filter.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/dataset.m
+++ b/inst/+tblish/+internal/dataset.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/generate_datasets_list.m
+++ b/inst/+tblish/+internal/generate_datasets_list.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/intersect_stable.m
+++ b/inst/+tblish/+internal/intersect_stable.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/mustHaveJava.m
+++ b/inst/+tblish/+internal/mustHaveJava.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/parse_ismissing_indicator.m
+++ b/inst/+tblish/+internal/parse_ismissing_indicator.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/peelOffNameValueOptions.m
+++ b/inst/+tblish/+internal/peelOffNameValueOptions.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/setdiff_stable.m
+++ b/inst/+tblish/+internal/setdiff_stable.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+internal/splitapply_impl.m
+++ b/inst/+tblish/+internal/splitapply_impl.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/+table/grpstats.m
+++ b/inst/+tblish/+table/grpstats.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/dataset.m
+++ b/inst/+tblish/dataset.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/dataset.m.in
+++ b/inst/+tblish/dataset.m.in
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/datasets.m
+++ b/inst/+tblish/datasets.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/evalWithTableVars.m
+++ b/inst/+tblish/evalWithTableVars.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/private/__eval_expr_with_table_vars_in_workspace__.m
+++ b/inst/+tblish/private/__eval_expr_with_table_vars_in_workspace__.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/+tblish/summary.m
+++ b/inst/+tblish/summary.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## x program is distributed in the hope that it will be useful,

--- a/inst/@categorical/categorical.m
+++ b/inst/@categorical/categorical.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/@string/string.m
+++ b/inst/@string/string.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/@table/table.m
+++ b/inst/@table/table.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/array2table.m
+++ b/inst/array2table.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/cell2table.m
+++ b/inst/cell2table.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/colvecfun.m
+++ b/inst/colvecfun.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/contains.m
+++ b/inst/contains.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/discretize.m
+++ b/inst/discretize.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/dispstrs.m
+++ b/inst/dispstrs.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/eqn.m
+++ b/inst/eqn.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/head.m
+++ b/inst/head.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/isnanny.m
+++ b/inst/isnanny.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/missing.m
+++ b/inst/missing.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/pp.m
+++ b/inst/pp.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/proxykeysForMatrixes.m
+++ b/inst/proxykeysForMatrixes.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/shims/compat/pre-5.0.0/isfile.m
+++ b/inst/shims/compat/pre-5.0.0/isfile.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/shims/compat/pre-5.0.0/isfolder.m
+++ b/inst/shims/compat/pre-5.0.0/isfolder.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/shims/compat/pre-6.0.0/mustBeFinite.m
+++ b/inst/shims/compat/pre-6.0.0/mustBeFinite.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/shims/compat/pre-6.0.0/mustBeInteger.m
+++ b/inst/shims/compat/pre-6.0.0/mustBeInteger.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/shims/compat/pre-6.0.0/mustBeMember.m
+++ b/inst/shims/compat/pre-6.0.0/mustBeMember.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/shims/compat/pre-6.0.0/mustBeNonempty.m
+++ b/inst/shims/compat/pre-6.0.0/mustBeNonempty.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/shims/compat/pre-6.0.0/mustBeNumeric.m
+++ b/inst/shims/compat/pre-6.0.0/mustBeNumeric.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/shims/compat/pre-6.0.0/mustBeReal.m
+++ b/inst/shims/compat/pre-6.0.0/mustBeReal.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/shims/compat/pre-7.0.0/endsWith.m
+++ b/inst/shims/compat/pre-7.0.0/endsWith.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/shims/compat/pre-7.0.0/startsWith.m
+++ b/inst/shims/compat/pre-7.0.0/startsWith.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/size2str.m
+++ b/inst/size2str.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/splitapply.m
+++ b/inst/splitapply.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/struct2table.m
+++ b/inst/struct2table.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/tail.m
+++ b/inst/tail.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/todatetime.m
+++ b/inst/todatetime.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/validators/mustBeA.m
+++ b/inst/validators/mustBeA.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/validators/mustBeCellstr.m
+++ b/inst/validators/mustBeCellstr.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/validators/mustBeCharvec.m
+++ b/inst/validators/mustBeCharvec.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/validators/mustBeSameSize.m
+++ b/inst/validators/mustBeSameSize.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/validators/mustBeScalar.m
+++ b/inst/validators/mustBeScalar.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/validators/mustBeScalarLogical.m
+++ b/inst/validators/mustBeScalarLogical.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/validators/mustBeVector.m
+++ b/inst/validators/mustBeVector.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/vartype.m
+++ b/inst/vartype.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,

--- a/inst/vecfun.m
+++ b/inst/vecfun.m
@@ -2,7 +2,7 @@
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
-## the Free Software Foundation; either version 2 of the License, or
+## the Free Software Foundation; either version 3 of the License, or
 ## (at your option) any later version.
 ##
 ## This program is distributed in the hope that it will be useful,


### PR DESCRIPTION
Addresses https://github.com/apjanke/octave-tablicious/issues/149.

Updates the source file headers for files originating with Tablicious to all say GPLv3+ as their license, instead of GPLv2+. The ones saying GPLv2+ were probably a copy-paste mistake. I intended to license all the Tablicious files under GPLv3+. GPLv2+ probably snuck in because some other projects I work on

The mktexi.pl and OctTexiDoc.pm files in doc/ should probably keep their GPLv2+ notice, because those files were copied from other projects that had GPLv2+ as their main licensing, and that preserves the original license info for them.